### PR TITLE
Remove extra comma form query on EZ page

### DIFF
--- a/admin/ezpages.php
+++ b/admin/ezpages.php
@@ -553,7 +553,7 @@ if (zen_not_null($action)) {
                 }
 
                 $pages_query_raw = "SELECT e.*, ec.*
-                                    FROM " . TABLE_EZPAGES . " e,
+                                    FROM " . TABLE_EZPAGES . " e
                                     INNER JOIN " . TABLE_EZPAGES_CONTENT . " ec USING (pages_id)
                                     WHERE ec.languages_id = " . (int)$_SESSION['languages_id'] . "
                                     " . $ez_order_by;


### PR DESCRIPTION
The comma results in an fatal error
